### PR TITLE
fix test: do not reuse sync.WaitGroup

### DIFF
--- a/sni_test.go
+++ b/sni_test.go
@@ -39,17 +39,18 @@ D2lWusoe2/nEqfDVVWGWlyJ7yOmqaVm/iNUN9B2N2g==
 `
 
 func TestSNI(t *testing.T) {
-	wg := new(sync.WaitGroup)
-	wg.Add(1)
+	server_started := new(sync.WaitGroup)
+	server_started.Add(1)
+	server_stopped := new(sync.WaitGroup)
+	server_stopped.Add(1)
 	go func() {
 		l, err := net.Listen("tcp", ":3000")
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer l.Close()
-		wg.Done()
-		wg.Add(1)
-		defer wg.Done()
+		server_started.Done()
+		defer server_stopped.Done()
 		conn, err := l.Accept()
 		if err != nil {
 			return
@@ -65,12 +66,12 @@ func TestSNI(t *testing.T) {
 		}
 		return
 	}()
-	wg.Wait()
+	server_started.Wait()
 	_, err := tls.Dial("tcp", "localhost:3000", nil)
 	if err != nil && err != io.EOF {
 		t.Fatal(err)
 	}
-	wg.Wait()
+	server_stopped.Wait()
 }
 
 func TestBuffConn(t *testing.T) {


### PR DESCRIPTION
Tests failed with the following error:

```
--- FAIL: TestSNI (0.00s)
panic: sync: WaitGroup is reused before previous Wait has returned [recovered]
    panic: sync: WaitGroup is reused before previous Wait has returned

goroutine 5 [running]:
panic(0x631420, 0xc82000aa90)
    goroot/src/runtime/panic.go:481 +0x3e6
testing.tRunner.func1(0xc820094120)
    goroot/src/testing/testing.go:467 +0x192
panic(0x631420, 0xc82000aa90)
    goroot/src/runtime/panic.go:443 +0x4e9
sync.(*WaitGroup).Wait(0xc82000aa70)
    goroot/src/sync/waitgroup.go:129 +0x114
github.com/polvi/sni.TestSNI(0xc820094120)
    gopath/src/github.com/polvi/sni/sni_test.go:68 +0x90
testing.tRunner(0xc820094120, 0x842560)
    goroot/src/testing/testing.go:473 +0x98
created by testing.RunTests
    goroot/src/testing/testing.go:582 +0x892
exit status 2
FAIL    github.com/polvi/sni    0.004s
```

Documentation of sync.WaitGroup says that main goroutine calls Add()
and child goroutine calls Done().
